### PR TITLE
Add another template setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ You can create custome template with a generator like following.
 
 This generator command generates `app/views/ajax_errors/_error.html.erb`, and you can customize it freely.
 
+To use another templates, you can use `template` argument.
+
+```ruby
+render_ajax_error model: @user, template: 'critical_error'
+```
+
+Template `app/views/ajax_errors/_critical_error.html.erb` will use.
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/app/views/ajax_errors/error.js.erb
+++ b/app/views/ajax_errors/error.js.erb
@@ -1,5 +1,5 @@
 var element = document.querySelector('<%= @location %>');
-element.innerHTML = "<%= j(render('ajax_errors/error', model: @model)) %>";
+element.innerHTML = "<%= j(render("ajax_errors/#{@template}", model: @model)) %>";
 <% if @move %>
 element.scrollIntoView(true);
 <% end %>

--- a/lib/ajax_error_renderer.rb
+++ b/lib/ajax_error_renderer.rb
@@ -3,10 +3,11 @@ require "ajax_error_renderer/engine"
 module AjaxErrorRenderer
   private
 
-  def render_ajax_error(location: '#error', model:, status: 422, move: true)
+  def render_ajax_error(location: '#error', model:, status: 422, move: true, template: 'error')
     @location = location
     @model = model
     @move = move
+    @template = template
     render 'ajax_errors/error', formats: :js, status: status
   end
 end

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
     if @user.update(user_params)
       redirect_to @user, notice: 'User was successfully updated.'
     else
-      render_ajax_error model: @user
+      render_ajax_error model: @user, template: 'update_error'
     end
   end
 

--- a/test/dummy/app/views/ajax_errors/_update_error.html.erb
+++ b/test/dummy/app/views/ajax_errors/_update_error.html.erb
@@ -1,0 +1,9 @@
+<% if model.errors.any? %>
+  <div id="update_error_explanation" class="alert alert-danger">
+    <ul>
+      <% model.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/test/dummy/test/system/users_test.rb
+++ b/test/dummy/test/system/users_test.rb
@@ -28,6 +28,7 @@ class UsersTest < ApplicationSystemTestCase
     click_on "Create User"
 
     assert_text "Name can't be blank"
+    assert page.has_css?('#error_explanation')
   end
 
   test "updating a User" do
@@ -39,6 +40,17 @@ class UsersTest < ApplicationSystemTestCase
 
     assert_text "User was successfully updated"
     click_on "Back"
+  end
+
+  test "updating a User with blank name" do
+    visit users_url
+    click_on "Edit", match: :first
+
+    fill_in "Name", with: ''
+    click_on "Update User"
+
+    assert_text "Name can't be blank"
+    assert page.has_css?('#update_error_explanation')
   end
 
   test "destroying a User" do


### PR DESCRIPTION
`ajax_error_renderer` is very convenient. I like it.

I added a new feature to use any templates other than `_error.html.erb` .
It is useful when you want to divide templates between end users and admins.